### PR TITLE
utilsforecast 0.2.12 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,28 +1,29 @@
 {% set name = "utilsforecast" %}
-{% set version = "0.0.10" %}
+{% set version = "0.2.12" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 08c01d57a7d221bb0dc34ed72279b6a97795de441adfbe11f4a84ad2ce635c72
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 73f9dfd836a721a95c349f784bd75e18a4cb7c1469800e325414e22901e9775b
 
 build:
   number: 0
-  skip: true  # [py<38]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  skip: true  # [py<39]
 
 requirements:
   host:
-    - python
     - pip
-    - setuptools
+    - python
     - wheel
+    - setuptools >=36.2
   run:
     - python
     - numpy
+    - packaging
     - pandas >=1.1.1
 
 test:


### PR DESCRIPTION
utilsforecast 0.2.12 

**Destination channel:** Defaults

### Links

- [PKG-10031]
- dev_url:        https://github.com/Nixtla/utilsforecast/tree/v0.2.12
- conda_forge:    https://github.com/conda-forge/utilsforecast-feedstock
- pypi:           https://pypi.org/project/utilsforecast/0.2.12
- pypi inspector: https://inspector.pypi.io/project/utilsforecast/0.2.12

### Explanation of changes:

- new version number


[PKG-10031]: https://anaconda.atlassian.net/browse/PKG-10031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ